### PR TITLE
new landing — try it out link

### DIFF
--- a/src/components/index-page/hero/index.tsx
+++ b/src/components/index-page/hero/index.tsx
@@ -29,8 +29,9 @@ export function Hero() {
           </ul>
 
           <div className="flex items-center gap-4">
-            <Button href="/learn" className="max-sm:w-full">
-              Learn more<span className="sr-only"> about GraphQL</span>
+            <Button href="/learn/#try-it-out">Try it out</Button>
+            <Button href="/learn" variant="secondary">
+              <span className="sr-only">Read the </span> Docs
             </Button>
           </div>
         </div>

--- a/vercel.json
+++ b/vercel.json
@@ -591,6 +591,11 @@
       "permanent": true
     },
     {
+      "source": "/docs",
+      "destination": "/learn",
+      "permanent": true
+    },
+    {
       "source": "/conf/2025/event-resources",
       "destination": "https://sites.google.com/linuxfoundation.org/graphqlconf2025event-resources/event-resources",
       "permanent": false


### PR DESCRIPTION
## Description

As a first step towards @martinbonnin's idea ([on Slack](https://northstar-e5s5760.slack.com/archives/C05N7STV6J1/p1755181239197609?thread_ts=1755180575.714419&cid=C05N7STV6J1)) before I catch the designers on a call on Tuesday and restyle CodeMirror, this PR:

- adds the <kbd>Try it out</kbd> CTA,
- and changes <kbd>Learn more</kbd> to Docs, because we already have <kbd>Learn</kbd> link in the navbar,
- I also added a redirect from `/docs` to `/learn`, because when I go to a technology website I usually just go straight to the docs. I'm one of the few weird people who read them from top to bottom when they're learning something new.